### PR TITLE
Integrated region

### DIFF
--- a/DCEL_CUTS/DCEL_Region.cpp
+++ b/DCEL_CUTS/DCEL_Region.cpp
@@ -578,3 +578,43 @@ void subAllocate(Region * target, FLL<Pint> const & boundary,
 		delete target;
 	}
 }
+
+void Region::clean() {
+	for (auto border : Boundaries) {
+		auto og_root = border->getRoot();
+		auto focus = og_root;
+
+		while(true) {
+			auto next = focus->getNext();
+			
+			// mid point degree is two test
+			if (focus->getInv()->getLast() == next->getInv()) {
+
+				bool parallel = false;
+
+				// parallel test
+				Pint a = focus->getEnd()->getPosition() - focus->getStart()->getPosition();
+				Pint b = next->getEnd()->getPosition() - next->getStart()->getPosition();
+
+				if (a.Y != 0 && b.Y != 0) {
+					rto x = a.X / a.Y;
+					rto y = b.X / b.Y;
+					parallel = x == y;
+				}
+				else if (a.Y == 0 && b.Y == 0) {
+					parallel = true;
+				}
+
+				if (parallel) {
+					next->getInv()->contract();
+				}
+			}
+
+			if (next == og_root) {
+				break;
+			}
+
+			focus = focus->getNext();
+		}
+	}
+}

--- a/DCEL_CUTS/DCEL_Region.cpp
+++ b/DCEL_CUTS/DCEL_Region.cpp
@@ -506,7 +506,7 @@ void subAllocate(Region * target, FLL<Pint> const & boundary,
 	else {
 		determineInteriors(target, details, exterior_faces, interior_faces);
 
-		//find regions, place holes
+	//find regions, place holes
 
 	//determine clockwise faces
 	//determine clockwise containment tree

--- a/DCEL_CUTS/DCEL_Region.cpp
+++ b/DCEL_CUTS/DCEL_Region.cpp
@@ -559,7 +559,7 @@ void subAllocate(Region<Pint> * target, FLL<Pint> const & boundary,
 			exteriors.push(novel);
 		}
 
-		delete target;
+		target->getUni()->removeRegion(target);
 	}
 }
 

--- a/DCEL_CUTS/DCEL_Region.cpp
+++ b/DCEL_CUTS/DCEL_Region.cpp
@@ -108,26 +108,8 @@ FaceRelationType const getPointRelation(FLL<Pint> const & rel, Pint const &test_
 	}
 }
 
-Region::Region(DCEL<Pint>* uni)
-{
-	universe = uni;
-}
-
-Region::Region(DCEL<Pint>* uni, FLL<Pint> const &bounds)
-{
-	universe = uni;
-	Boundaries.append(uni->draw(bounds));
-}
-
-Region::Region(DCEL<Pint>* uni, Face<Pint>* source)
-{
-	Boundaries.push(source);
-
-	universe = uni;
-}
-
-FaceRelation Region::contains(Pint const & test_point) {
-	for(auto focus : Boundaries) {
+FaceRelation contains(Region<Pint> * target, Pint const & test_point) {
+	for(auto focus : target->getBounds()) {
 
 		FaceRelation result = getPointRelation(*focus, test_point);
 		if (result.type != FaceRelationType::point_interior) {
@@ -138,7 +120,7 @@ FaceRelation Region::contains(Pint const & test_point) {
 	return FaceRelation(FaceRelationType::point_interior, nullptr);
 }
 
-bool Region::merge(Region * target) {
+bool merge(Region<Pint> * a, Region<Pint> * b) {
 	//since both areas are continuous, its trivial that only one or no boundary pair can touch
 	
 	//regions are either strictly internal, strictly external, or weakly external to boundaries
@@ -147,11 +129,11 @@ bool Region::merge(Region * target) {
 	
 	Face<Pint> * local_face = nullptr;
 	Face<Pint> * target_face = nullptr;
-	for(auto focus_local : Boundaries) {
+	for(auto focus_local : a->getBounds()) {
 
 		auto neighbors = focus_local->getNeighbors();
 
-		for (auto focus_target : target->Boundaries) {
+		for (auto focus_target : b->getBounds()) {
 
 			if (neighbors.contains(focus_target)) {
 				local_face = focus_local;
@@ -172,11 +154,13 @@ bool Region::merge(Region * target) {
 	auto tba = local_face->mergeWithFace(target_face);
 
 	//now edit the boundary lists of both regions
-	Boundaries.remove(local_face);
+	a->remove(local_face);
 
-	Boundaries.absorb(tba); //TODO: rvalues
+	for (auto face : tba) {
+		b->append(face);
+	}
 
-	target->Boundaries.clear();
+	a->clear();
 
 	return true;
 }
@@ -285,14 +269,14 @@ FLL<intersect *> findIntersects(Pint const & start, Pint const & stop,
 
 //finds interact features for a suballocation, and subidivides region edges where needed
 //returns true if boundary is entirely external
-bool markRegion(Region * target, FLL<Pint> const & boundary, FLL<interact *>  & details) {
+bool markRegion(Region<Pint> * target, FLL<Pint> const & boundary, FLL<interact *>  & details) {
 	
 	bool exterior = true;
 
 	{
 		FLL<Edge<Pint> *> canidates;
 
-		for(auto const & canidate_focus : target->Boundaries) {
+		for(auto canidate_focus : target->getBounds()) {
 			auto tba = canidate_focus->getLoopEdges(); //TODO: rvalues
 			canidates.absorb(tba);
 		}
@@ -346,7 +330,7 @@ bool markRegion(Region * target, FLL<Pint> const & boundary, FLL<interact *>  & 
 
 			if (!end_collision) {
 
-				auto state = target->contains(next);
+				auto state = contains(target, next);
 
 
 
@@ -371,7 +355,7 @@ bool markRegion(Region * target, FLL<Pint> const & boundary, FLL<interact *>  & 
 		for(auto next : details) {
 			last->mid = (last->location + next->location) / 2;
 
-			auto result = target->contains(last->mid);
+			auto result = contains(target, last->mid);
 
 			last->mid_interior = (result.type != FaceRelationType::point_exterior);
 
@@ -383,10 +367,10 @@ bool markRegion(Region * target, FLL<Pint> const & boundary, FLL<interact *>  & 
 }
 
 //insert strands into target, and determine face inclusions
-void determineInteriors(Region * target, FLL<interact *> & details,
+void determineInteriors(Region<Pint> * target, FLL<interact *> & details,
 	FLL<Face<Pint> *> & exteriors, FLL<Face<Pint> *> & interiors) {
 
-	exteriors = target->Boundaries;
+	exteriors = target->getBounds();
 
 	auto last = details.begin();
 	auto next = last.cyclic_next();
@@ -400,13 +384,13 @@ void determineInteriors(Region * target, FLL<interact *> & details,
 
 		if (into->type == FaceRelationType::point_interior) {
 
-			into->mark = target->universe->addEdge(from->location, into->location);
+			into->mark = target->getUni()->addEdge(from->location, into->location);
 
 			from->mark = into->mark->getInv();
 		}
 		else if (into->type == FaceRelationType::point_on_boundary) {
 
-			from->mark = target->universe->addEdge(into->mark, from->location);
+			from->mark = target->getUni()->addEdge(into->mark, from->location);
 
 			into->mark = from->mark->getInv();
 		}
@@ -425,7 +409,7 @@ void determineInteriors(Region * target, FLL<interact *> & details,
 		if (from->type != FaceRelationType::point_exterior) {
 			if (into->type == FaceRelationType::point_interior) {
 
-				into->mark = target->universe->addEdge(from->mark, into->location);
+				into->mark = target->getUni()->addEdge(from->mark, into->location);
 
 			}
 			else if (into->type == FaceRelationType::point_on_boundary) {
@@ -437,7 +421,7 @@ void determineInteriors(Region * target, FLL<interact *> & details,
 						if (from->mid_interior) {
 							exteriors.remove(into->mark->getFace());
 
-							auto created = target->universe->addEdge(from->mark, into->mark);
+							auto created = target->getUni()->addEdge(from->mark, into->mark);
 
 							if (getPointRelation(*created->getFace(),into->mid).type != FaceRelationType::point_exterior) {
 								into->mark = created;
@@ -452,7 +436,7 @@ void determineInteriors(Region * target, FLL<interact *> & details,
 					else {
 						exteriors.remove(into->mark->getFace());
 
-						into->mark = target->universe->addEdge(from->mark, into->mark);
+						into->mark = target->getUni()->addEdge(from->mark, into->mark);
 					}
 				}
 			}
@@ -476,8 +460,8 @@ void determineInteriors(Region * target, FLL<interact *> & details,
 	}
 }
 
-void subAllocate(Region * target, FLL<Pint> const & boundary,
-	FLL<Region *> & exteriors, FLL<Region *> & interiors) {
+void subAllocate(Region<Pint> * target, FLL<Pint> const & boundary,
+	FLL<Region<Pint> *> & exteriors, FLL<Region<Pint> *> & interiors) {
 	//subdivide all edges based on intersects
 	//this means all boundary edges are either
 	//exterior
@@ -494,7 +478,7 @@ void subAllocate(Region * target, FLL<Pint> const & boundary,
 
 	if (exterior) {
 
-		auto test = (*target->Boundaries.begin())->getRoot()->getStart()->getPosition();
+		auto test = (*target->getBounds().begin())->getRoot()->getStart()->getPosition();
 		if (getPointRelation(boundary, test) == FaceRelationType::point_interior) {
 
 			interiors.push(target);
@@ -517,7 +501,7 @@ void subAllocate(Region * target, FLL<Pint> const & boundary,
 
 	//for each interior face, create a region, add any symmetricly contained exterior faces to that region
 		for(auto interior_face : interior_faces) {
-			Region* novel = new Region(target->universe);
+			Region<Pint> * novel = target->getUni()->region();
 
 			auto interior_root = interior_face->getRoot()->getStart()->getPosition();
 
@@ -534,13 +518,13 @@ void subAllocate(Region * target, FLL<Pint> const & boundary,
 				++exterior_focus;
 
 				if (ex_contains_in.type == FaceRelationType::point_interior && in_contains_ex.type == FaceRelationType::point_interior) {
-					novel->Boundaries.push(exterior_face);
+					novel->append(exterior_face);
 
 					exterior_faces.remove(exterior_face);
 				}
 			}
 
-			novel->Boundaries.push(interior_face);
+			novel->append(interior_face);
 
 			interiors.push(novel);
 		}
@@ -548,7 +532,7 @@ void subAllocate(Region * target, FLL<Pint> const & boundary,
 		//for each exterior face, see which faces are symmetric with it and create regions
 
 		for (auto exterior_focus = exterior_faces.begin(); exterior_focus != exterior_faces.end(); ++exterior_focus) {
-			Region* novel = new Region(target->universe);
+			Region<Pint> * novel = target->getUni()->region();
 
 			auto base_face = *exterior_focus;
 			auto base_root = base_face->getRoot()->getStart()->getPosition();
@@ -564,13 +548,13 @@ void subAllocate(Region * target, FLL<Pint> const & boundary,
 				++compare;
 
 				if (comp_contains_base.type == FaceRelationType::point_interior && base_contains_comp.type == FaceRelationType::point_interior) {
-					novel->Boundaries.push(comp_face);
+					novel->append(comp_face);
 
 					exterior_faces.remove(comp_face);
 				}
 			}
 
-			novel->Boundaries.push(base_face);
+			novel->append(base_face);
 
 			exteriors.push(novel);
 		}
@@ -579,8 +563,8 @@ void subAllocate(Region * target, FLL<Pint> const & boundary,
 	}
 }
 
-void Region::clean() {
-	for (auto border : Boundaries) {
+void cleanRegion(Region<Pint> * target) {
+	for (auto border : target->getBounds()) {
 		auto og_root = border->getRoot();
 		auto focus = og_root;
 

--- a/DCEL_CUTS/DCEL_Region.h
+++ b/DCEL_CUTS/DCEL_Region.h
@@ -44,44 +44,19 @@ struct FaceRelation {
 
 FaceRelation const getPointRelation(Face<Pint> &rel, Pint const &test_point);
 
-class Region {
-	FLL<Face<Pint> *> Boundaries;
-	DCEL<Pint> * universe;
+bool merge(Region<Pint> * a, Region<Pint> * b);
 
-	friend void determineInteriors(Region *, FLL<interact *> &,
-		FLL<Face<Pint> *> &, FLL<Face<Pint> *> &);
+void determineInteriors(Region<Pint> *, FLL<interact *> &, FLL<Face<Pint> *> &, 
+	FLL<Face<Pint> *> &);
 
-	friend bool markRegion(Region *, FLL<Pint> const &, FLL<interact *> &);
+bool markRegion(Region<Pint> *, FLL<Pint> const &, FLL<interact *> &);
 
+//type dependent
+void subAllocate(Region<Pint> * target, FLL<Pint> const & boundary, 
+	FLL<Region<Pint> *> &exteriors, FLL<Region<Pint> *> & interiors);
 
-	friend void subAllocate(Region* target, FLL<Pint> const & boundary, FLL<Region*> &exteriors, FLL<Region *> & interiors);
+FaceRelation contains(Region<Pint> * target, Pint const & test_point);
 
-public:
-	Region(DCEL<Pint> *);
-	Region(DCEL<Pint> *, FLL<Pint> const &);
-	Region(DCEL<Pint> *, Face<Pint> *);
+FLL<Region<Pint> *> getNeighbors(Region<Pint> * target);
 
-	FLL< Face<Pint> *> const * getBounds() const {
-		return &Boundaries;
-	}
-
-	//returns nullptr if out of bounds
-	Face<Pint> * operator[](int index) {
-		return Boundaries[index];
-	}
-
-	int size() const {
-		return Boundaries.size();
-	}
-
-	FaceRelation contains(Pint const & test_point) ;
-
-	//if non-trivially connected, will absorb the target region into this one via face merging
-	bool merge(Region*);
-
-	//merges parrallel adjacent edges who's mid point has a degree of just two
-	void clean();
-
-};
-
-
+void cleanRegion(Region<Pint> * target);

--- a/DCEL_CUTS/DCEL_Region.h
+++ b/DCEL_CUTS/DCEL_Region.h
@@ -79,6 +79,9 @@ public:
 	//if non-trivially connected, will absorb the target region into this one via face merging
 	bool merge(Region*);
 
+	//merges parrallel adjacent edges who's mid point has a degree of just 2
+	void clean();
+
 };
 
 

--- a/DCEL_CUTS/DCEL_Region.h
+++ b/DCEL_CUTS/DCEL_Region.h
@@ -79,7 +79,7 @@ public:
 	//if non-trivially connected, will absorb the target region into this one via face merging
 	bool merge(Region*);
 
-	//merges parrallel adjacent edges who's mid point has a degree of just 2
+	//merges parrallel adjacent edges who's mid point has a degree of just two
 	void clean();
 
 };

--- a/DCEL_CUTS/DCEL_fll.h
+++ b/DCEL_CUTS/DCEL_fll.h
@@ -187,6 +187,15 @@ public:
 
 		length++;
 	}
+	void append(FLL<_T> reference) {
+		FLL_node * focus = reference.head;
+
+		while (focus != nullptr) {
+			append(focus->value);
+
+			focus = focus->next;
+		}
+	}
 
 	//returns the element at head, undefined behavior if empty
 	_T pop() {

--- a/DCEL_CUTS/DCEL_point.h
+++ b/DCEL_CUTS/DCEL_point.h
@@ -76,10 +76,10 @@ struct PBox {
 	Pint Min;
 	Pint Max;
 
-	Pint getExtent() {
+	Pint getExtent() const {
 		return (Max - Min) / 2;
 	}
-	Pint getCenter() {
+	Pint getCenter() const {
 		return (Max + Min) / 2;
 	}
 };

--- a/DCEL_CUTS/DCEL_types.h
+++ b/DCEL_CUTS/DCEL_types.h
@@ -435,7 +435,7 @@ public:
 		do {
 			focus->root = root;
 			focus = focus->inv->next;
-		} while (focus != next);
+		} while (focus != inv);
 
 		root->root = next;
 
@@ -445,7 +445,15 @@ public:
 		inv->next->last = inv->last;
 		inv->last->next = inv->next;
 
+		if (loop->root == this) {
+			loop->root = next;
+		}
+		if (inv->loop->root == inv) {
+			inv->loop->root = inv->last;
+		}
+
 		universe->removePoint(inv->root);
+		universe->removeEdge(this);
 	}
 
 };

--- a/DCEL_CUTS/DCEL_types.h
+++ b/DCEL_CUTS/DCEL_types.h
@@ -693,7 +693,7 @@ public:
 			}
 
 			border->group = this;
-			Boundaries.append(border);
+			Boundaries.push(border);
 		}
 	}
 	void remove(Face<Pint> * border) {

--- a/DCEL_CUTS/DCEL_types.h
+++ b/DCEL_CUTS/DCEL_types.h
@@ -585,6 +585,21 @@ public:
 		return target;
 	}
 
+	FLL<Face<_P> *> getNeighbors() {
+		FLL<Face<_P> *> target;
+		Edge<_P> * focus = root;
+
+		do {
+			Face<_P> * canidate = focus->inv->loop;
+			if (!target.contains(canidate)) {
+				target.append(canidate);
+			}
+			focus = focus->next;
+		} while (focus != root);
+
+		return target;
+	}
+
 	//return a list of the faces that share a boundary in the loop
 	FLL<Face<_P> const *> getNeighbors() const {
 		FLL<Face<_P> const *> target;
@@ -725,6 +740,21 @@ public:
 
 	DCEL<_P> * getUni() {
 		return universe;
+	}
+
+	FLL<Region *> getNeighbors() {
+		FLL<Region *> product;
+
+		for (auto border : Boundaries) {
+			auto canidates = border->getNeighbors();
+			for (auto suggest : canidates) {
+				if (!product.contains(suggest->group)) {
+					product.push(suggest->group);
+				}
+			}
+		}
+
+		return product;
 	}
 
 };

--- a/DCEL_CUTS/DCEL_types.h
+++ b/DCEL_CUTS/DCEL_types.h
@@ -12,6 +12,7 @@ The structure specifically details how regions who have intersecting boundaries 
 template <class _P> class Point;
 template <class _P> class Edge;
 template <class _P> class Face;
+template <class _P> class Region;
 template <class _P> class DCEL;
 
 // Represents a point in space, the ends of edges, and corners of faces
@@ -462,14 +463,21 @@ public:
 template <class _P>
 class Face {
 	friend DCEL<_P>;
+	friend Region<_P>;
 	friend Edge<_P>;
 
 	DCEL<_P> * universe;
 
 	Edge<_P> * root;
 
+	Region<_P> * group;
+
 	//this can only be created through DCEL system functions
 	Face(DCEL<_P> * uni) {
+		universe = uni;
+		group = nullptr;
+	}
+	Face(DCEL<_P> * uni, Region<_P> * grp) {
 		universe = uni;
 	}
 	Face(Face<_P> &&) = delete;
@@ -477,7 +485,6 @@ class Face {
 
 	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	//         Modifiers
-
 	//sets all edges of this loop to reference this
 	void reFace() {
 		Edge<_P> * focus = root;
@@ -497,6 +504,14 @@ public:
 
 	Edge<_P> const * getRoot() const {
 		return root;
+	}
+
+	Region<_P> * getGroup() {
+		return group;
+	}
+
+	Region<_P> const * getGroup() const {
+		return group;
 	}
 
 	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -649,10 +664,66 @@ public:
 };
 
 template <class _P>
+class Region {
+	friend DCEL<_P>;
+
+	DCEL<_P> * universe;
+
+	Region(DCEL<Pint> * uni) {
+		universe = uni;
+	}
+	FLL<Face<_P> *> Boundaries;
+
+public:
+	FLL<Face<_P> *> const & getBounds() {
+		return Boundaries;
+	}
+	Face<_P> * operator[](int a) {
+		return Boundaries[a];
+	}
+
+	int size() const {
+		return Boundaries.size();
+	}
+
+	void append(Face<Pint> * border) {
+		if (border->group != this) {
+			if (border->group != nullptr) {
+				border->group->remove(border);
+			}
+
+			border->group = this;
+			Boundaries.append(border);
+		}
+	}
+	void remove(Face<Pint> * border) {
+		if (border->group == this) {
+			border->group = nullptr;
+			Boundaries.remove(border);
+		}
+	}
+	void clear() {
+		for (auto border : Boundaries) {
+			border->group = nullptr;
+		}
+
+		Boundaries.clear();
+	}
+
+	DCEL<_P> * getUni() {
+		return universe;
+	}
+
+};
+
+
+
+template <class _P>
 class DCEL {
 	FLL<Point<_P> *> points;
 	FLL<Edge<_P> *> edges;
 	FLL<Face<_P> *> faces;
+	FLL<Region<_P> *> regions;
 
 	friend Edge<_P>;
 
@@ -686,17 +757,15 @@ class DCEL {
 	}
 
 	//removes a point
-	//does NOT check to see if references elsewhere
+	//does NOT check to see if referenced elsewhere
 	void removePoint(Point<_P> * target) {
-		//is it ACTUALLY disconnected? AHHHHHHHHH
 		points.remove(target);
 
 		delete target;
 	}
 	//removes an edge and its inverse
-	//does NOT check to see if references elsewhere
+	//does NOT check to see if referenced elsewhere
 	void removeEdge(Edge<_P> * target) {
-		//is it ACTUALLY disconnected? AHHHHHHHHH
 		edges.remove(target);
 		edges.remove(target->inv);
 
@@ -704,10 +773,16 @@ class DCEL {
 		delete target;
 	}
 	//removes a face
-	//does NOT check to see if references elsewhere
+	//does NOT check to see if referenced elsewhere
 	void removeFace(Face<_P> * target) {
-		//is it ACTUALLY disconnected? AHHHHHHHHH
 		faces.remove(target);
+
+		delete target;
+	}
+	//removes a region
+	//does NOT check to see if referenced elsewhere
+	void removeFace(Region<_P> * target) {
+		regions.remove(target);
 
 		delete target;
 	}
@@ -724,6 +799,10 @@ public:
 
 		for (auto focus_face : faces) {
 			delete focus_face;
+		}
+
+		for (auto focus_region : regions) {
+			delete focus_region;
 		}
 	}
 
@@ -828,6 +907,24 @@ public:
 		return result;
 	}
 
+	Region<_P> * region() {
+		Region<_P> * product = new Region<_P>(this);
+		regions.append(product);
+		return product;
+	}
+
+	Region<_P> * region(Face<_P> * face) {
+		Region<_P> * product = new Region<_P>(this);
+		product->append(face);
+		regions.append(product);
+		return product;
+	}
+	Region<_P> * region(FLL<_P> const &boundary) {
+		Region<_P> * product = new Region<_P>(this);
+		product->append(draw(boundary));
+		regions.append(product);
+		return product;
+	}
 
 	//creates a circular chain of edges forming a loop with the given boundary
 	//returns a pointer to the clock-wise oriented interior of the boundary

--- a/DCEL_CUTS/DCEL_types.h
+++ b/DCEL_CUTS/DCEL_types.h
@@ -37,6 +37,10 @@ class Point {
 	};
 	Point(Point<_P> &&) = delete;
 	Point(Point<_P> const &) = delete;
+
+	~Point() {
+
+	}
 public:
 	void setPosition(_P p) {
 		position = p;
@@ -102,6 +106,10 @@ class Edge {
 	}
 	Edge(Edge<_P> &&) = delete;
 	Edge(Edge<_P> const &) = delete;
+
+	~Edge() {
+
+	}
 public:
 	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	//         Traversal Methods
@@ -483,6 +491,10 @@ class Face {
 	Face(Face<_P> &&) = delete;
 	Face(Face<_P> const &) = delete;
 
+	~Face() {
+
+	}
+
 	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	//         Modifiers
 	//sets all edges of this loop to reference this
@@ -659,8 +671,6 @@ public:
 		}
 		return product;
 	}
-
-	//void cleanBorder();
 };
 
 template <class _P>
@@ -671,6 +681,9 @@ class Region {
 
 	Region(DCEL<Pint> * uni) {
 		universe = uni;
+	}
+	~Region() {
+
 	}
 	FLL<Face<_P> *> Boundaries;
 

--- a/DCEL_CUTS/DCEL_types.h
+++ b/DCEL_CUTS/DCEL_types.h
@@ -779,13 +779,6 @@ class DCEL {
 
 		delete target;
 	}
-	//removes a region
-	//does NOT check to see if referenced elsewhere
-	void removeFace(Region<_P> * target) {
-		regions.remove(target);
-
-		delete target;
-	}
 
 public:
 	~DCEL() {
@@ -814,6 +807,9 @@ public:
 	}
 	int faceCount() const {
 		return faces.size();
+	}
+	int regionCount() const {
+		return regions.size();
 	}
 
 	//creates an edge and its inverse connecting two novel points
@@ -953,6 +949,11 @@ public:
 		return start->loop;
 	}
 
+	//removes a region
+	//does NOT check to see if referenced elsewhere
+	void removeRegion(Region<_P> * target) {
+		regions.remove(target);
 
-	//void sanityCheck(); TODO
+		delete target;
+	}
 };

--- a/TESTS/TEST_region.cpp
+++ b/TESTS/TEST_region.cpp
@@ -7,7 +7,7 @@ TEST(Region_Basics, Region_Creation) {
 	DCEL<Pint> space;
 
 	//results
-	Region * product, * null;
+	Region<Pint> * product, * null;
 
 	//tested operations are performed within this block
 	{
@@ -19,11 +19,11 @@ TEST(Region_Basics, Region_Creation) {
 			boundary_big.append(Pint(20, 0));
 		}
 
-		product = new Region(&space, boundary_big);
+		product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 	}
 
 	//testing
@@ -114,16 +114,16 @@ TEST(Region_Basics, Region_Contains) {
 		boundary_big.append(Pint(20, 0));
 	}
 
-	Region * target = new Region(&space, boundary_big);
+	auto product = space.region(boundary_big);
 
 	//inside simple
-	EXPECT_EQ(target->contains(Pint(2,2)).type, FaceRelationType::point_interior);
+	EXPECT_EQ(contains(product, Pint(2,2)).type, FaceRelationType::point_interior);
 
 	//outside simple
-	EXPECT_EQ(target->contains(Pint(-2, 2)).type, FaceRelationType::point_exterior);
+	EXPECT_EQ(contains(product, Pint(-2, 2)).type, FaceRelationType::point_exterior);
 
 	//boundary simple
-	EXPECT_EQ(target->contains(Pint(0, 2)).type, FaceRelationType::point_on_boundary);
+	EXPECT_EQ(contains(product, Pint(0, 2)).type, FaceRelationType::point_on_boundary);
 }
 
 
@@ -133,9 +133,9 @@ TEST(Face_Cuts, Hole) {
 	DCEL<Pint> space;
 	
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -154,11 +154,11 @@ TEST(Face_Cuts, Hole) {
 			boundary_small_a.append(Pint(4, 2));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -175,8 +175,8 @@ TEST(Face_Cuts, Hole) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -206,19 +206,19 @@ TEST(Face_Cuts, Hole) {
 	auto area_null_0 = Pint::area(null_0->getLoopPoints());
 
 	EXPECT_TRUE(area_in_0_0 == rto(4));
-	EXPECT_TRUE(area_ex_0_0 == rto(-4));
-	EXPECT_TRUE(area_ex_0_1 == rto(400));
+	EXPECT_TRUE(area_ex_0_0 == rto(400));
+	EXPECT_TRUE(area_ex_0_1 == rto(-4));
 	EXPECT_TRUE(area_null_0 == rto(-400));
 
-	EXPECT_TRUE(interior_0_0->getNeighbors().contains(exterior_0_0));
-	EXPECT_FALSE(interior_0_0->getNeighbors().contains(exterior_0_1));
+	EXPECT_FALSE(interior_0_0->getNeighbors().contains(exterior_0_0));
+	EXPECT_TRUE(interior_0_0->getNeighbors().contains(exterior_0_1));
 	EXPECT_FALSE(interior_0_0->getNeighbors().contains(null_0));
 
-	EXPECT_TRUE(exterior_0_0->getNeighbors().contains(interior_0_0));
+	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(interior_0_0));
 	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(exterior_0_1));
 	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(null_0));
 
-	EXPECT_FALSE(exterior_0_1->getNeighbors().contains(interior_0_0));
+	EXPECT_TRUE(exterior_0_1->getNeighbors().contains(interior_0_0));
 	EXPECT_FALSE(exterior_0_1->getNeighbors().contains(exterior_0_0));
 	EXPECT_TRUE(exterior_0_1->getNeighbors().contains(null_0));
 
@@ -234,9 +234,9 @@ TEST(Face_Cuts, Edge_Meeting_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -255,11 +255,11 @@ TEST(Face_Cuts, Edge_Meeting_Cut) {
 			boundary_small_a.append(Pint(4, 2));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -276,8 +276,8 @@ TEST(Face_Cuts, Edge_Meeting_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -326,9 +326,9 @@ TEST(Face_Cuts, Point_Meeting_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -349,11 +349,11 @@ TEST(Face_Cuts, Point_Meeting_Cut) {
 			boundary_small_a.append(Pint(4, 2));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -370,8 +370,8 @@ TEST(Face_Cuts, Point_Meeting_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -416,9 +416,9 @@ TEST(Face_Cuts, Matching_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 
 	//tested operations are performed within this block
@@ -442,11 +442,11 @@ TEST(Face_Cuts, Matching_Cut) {
 			boundary_small_a.append(Pint(4, 2));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 		
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -463,8 +463,8 @@ TEST(Face_Cuts, Matching_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -509,9 +509,9 @@ TEST(Face_Cuts, Before_Overlapping_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 
 	//tested operations are performed within this block
@@ -535,11 +535,11 @@ TEST(Face_Cuts, Before_Overlapping_Cut) {
 			boundary_small_a.append(Pint(4, 1));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 
@@ -557,8 +557,8 @@ TEST(Face_Cuts, Before_Overlapping_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -604,9 +604,9 @@ TEST(Face_Cuts, After_Overlapping_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -629,11 +629,11 @@ TEST(Face_Cuts, After_Overlapping_Cut) {
 			boundary_small_a.append(Pint(3, 4));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -650,8 +650,8 @@ TEST(Face_Cuts, After_Overlapping_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -697,9 +697,9 @@ TEST(Face_Cuts, Overlapping_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	{
 		FLL<Pint> boundary_big;
@@ -721,11 +721,11 @@ TEST(Face_Cuts, Overlapping_Cut) {
 			boundary_small_a.append(Pint(4, 1));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -742,8 +742,8 @@ TEST(Face_Cuts, Overlapping_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -789,9 +789,9 @@ TEST(Face_Cuts, Stacked_Holes) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -817,13 +817,13 @@ TEST(Face_Cuts, Stacked_Holes) {
 			boundary_small_b.append(Pint(2, 4));
 		}
 
-		FLL<Region *> exterior_med;
+		FLL<Region<Pint> *> exterior_med;
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior_med, interior);
 
@@ -843,9 +843,9 @@ TEST(Face_Cuts, Stacked_Holes) {
 	ASSERT_NE(interior[1], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -905,9 +905,9 @@ TEST(Face_Cuts, Horshoe_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -930,11 +930,11 @@ TEST(Face_Cuts, Horshoe_Cut) {
 			boundary_small_a.append(Pint(16, -8));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -952,9 +952,9 @@ TEST(Face_Cuts, Horshoe_Cut) {
 	ASSERT_NE(interior[1], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -1013,9 +1013,9 @@ TEST(Face_Cuts, Corner_Meeting_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 
@@ -1035,11 +1035,11 @@ TEST(Face_Cuts, Corner_Meeting_Cut) {
 			boundary_small_a.append(Pint(4, 0));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -1056,8 +1056,8 @@ TEST(Face_Cuts, Corner_Meeting_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -1102,9 +1102,9 @@ TEST(Face_Cuts, Edge_Crossing_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1123,11 +1123,11 @@ TEST(Face_Cuts, Edge_Crossing_Cut) {
 			boundary_small_a.append(Pint(4, 2));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -1144,8 +1144,8 @@ TEST(Face_Cuts, Edge_Crossing_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -1190,9 +1190,9 @@ TEST(Face_Cuts, Corner_Crossing_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1211,11 +1211,11 @@ TEST(Face_Cuts, Corner_Crossing_Cut) {
 			boundary_small_a.append(Pint(4, -4));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -1232,8 +1232,8 @@ TEST(Face_Cuts, Corner_Crossing_Cut) {
 	ASSERT_NE(interior[0], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -1278,9 +1278,9 @@ TEST(Face_Cuts, Exterior_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1299,11 +1299,11 @@ TEST(Face_Cuts, Exterior_Cut) {
 			boundary_small_a.append(Pint(-2, 2));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -1325,9 +1325,9 @@ TEST(Face_Cuts, Encapsulating_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1346,11 +1346,11 @@ TEST(Face_Cuts, Encapsulating_Cut) {
 			boundary_small_a.append(Pint(22, -2));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -1366,7 +1366,7 @@ TEST(Face_Cuts, Encapsulating_Cut) {
 
 	ASSERT_NE(interior[0], nullptr);
 
-	Region * interior_0 = interior[0];
+	Region<Pint> * interior_0 = interior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 
@@ -1400,9 +1400,9 @@ TEST(Face_Cuts, Seperate_Holes) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1428,13 +1428,13 @@ TEST(Face_Cuts, Seperate_Holes) {
 			boundary_small_b.append(Pint(4, 16));
 		}
 
-		FLL<Region *> exterior_med;
+		FLL<Region<Pint> *> exterior_med;
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior_med, interior);
 
@@ -1454,9 +1454,9 @@ TEST(Face_Cuts, Seperate_Holes) {
 	ASSERT_NE(interior[1], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -1545,9 +1545,9 @@ TEST(Face_Cuts, Adjacent_Meeting_Holes) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1573,13 +1573,13 @@ TEST(Face_Cuts, Adjacent_Meeting_Holes) {
 			boundary_small_b.append(Pint(6, 4));
 		}
 
-		FLL<Region *> exterior_med;
+		FLL<Region<Pint> *> exterior_med;
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior_med, interior);
 
@@ -1599,9 +1599,9 @@ TEST(Face_Cuts, Adjacent_Meeting_Holes) {
 	ASSERT_NE(interior[1], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -1673,9 +1673,9 @@ TEST(Face_Cuts, Adjacent_Crossing_Holes) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1701,13 +1701,13 @@ TEST(Face_Cuts, Adjacent_Crossing_Holes) {
 			boundary_small_b.append(Pint(6, 4));
 		}
 
-		FLL<Region *> exterior_med;
+		FLL<Region<Pint> *> exterior_med;
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior_med, interior);
 
@@ -1725,9 +1725,9 @@ TEST(Face_Cuts, Adjacent_Crossing_Holes) {
 	ASSERT_NE(interior[1], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -1799,9 +1799,9 @@ TEST(Face_Cuts, Connecting_Holes) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1827,13 +1827,13 @@ TEST(Face_Cuts, Connecting_Holes) {
 			boundary_small_b.append(Pint(2, 4));
 		}
 
-		FLL<Region *> exterior_med;
+		FLL<Region<Pint> *> exterior_med;
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior_med, interior);
 
@@ -1853,9 +1853,9 @@ TEST(Face_Cuts, Connecting_Holes) {
 	ASSERT_NE(interior[1], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -1914,9 +1914,9 @@ TEST(Face_Cuts, Connecting_Several_Holes) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -1949,14 +1949,14 @@ TEST(Face_Cuts, Connecting_Several_Holes) {
 			boundary_small_c.append(Pint(16, 5));
 		}
 
-		FLL<Region *> exterior_med_a;
-		FLL<Region *> exterior_med_b;
+		FLL<Region<Pint> *> exterior_med_a;
+		FLL<Region<Pint> *> exterior_med_b;
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior_med_a, interior);
 
@@ -1999,10 +1999,10 @@ TEST(Face_Cuts, Connecting_Several_Holes) {
 	ASSERT_NE(interior[2], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * interior_2 = interior[2];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * interior_2 = interior[2];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -2093,9 +2093,9 @@ TEST(Face_Cuts, Splitting_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -2114,11 +2114,11 @@ TEST(Face_Cuts, Splitting_Cut) {
 			boundary_small_a.append(Pint(20, 5));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -2136,9 +2136,9 @@ TEST(Face_Cuts, Splitting_Cut) {
 	ASSERT_NE(exterior[0], nullptr);
 	ASSERT_NE(exterior[1], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * exterior_0 = exterior[0];
-	Region * exterior_1 = exterior[1];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * exterior_0 = exterior[0];
+	Region<Pint> * exterior_1 = exterior[1];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(exterior_0, nullptr);
@@ -2197,9 +2197,9 @@ TEST(Face_Cuts, Divided_Crossing_Holes) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -2225,13 +2225,13 @@ TEST(Face_Cuts, Divided_Crossing_Holes) {
 			boundary_small_b.append(Pint(16, 8));
 		}
 
-		FLL<Region *> exterior_med;
+		FLL<Region<Pint> *> exterior_med;
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior_med, interior);
 
@@ -2252,10 +2252,10 @@ TEST(Face_Cuts, Divided_Crossing_Holes) {
 	ASSERT_NE(interior[2], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * interior_2 = interior[2];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * interior_2 = interior[2];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -2346,9 +2346,9 @@ TEST(Face_Cuts, Triangles_Crossing_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -2368,11 +2368,11 @@ TEST(Face_Cuts, Triangles_Crossing_Cut) {
 			boundary_small_a.append(Pint(6, -1));
 		}
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior, interior);
 	}
@@ -2390,9 +2390,9 @@ TEST(Face_Cuts, Triangles_Crossing_Cut) {
 	ASSERT_NE(interior[1], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);
@@ -2451,9 +2451,9 @@ TEST(Face_Cuts, Divided_Meet_Cut) {
 	DCEL<Pint> space;
 
 	//results
-	FLL<Region *> interior;
-	FLL<Region *> exterior;
-	Region * null;
+	FLL<Region<Pint> *> interior;
+	FLL<Region<Pint> *> exterior;
+	Region<Pint> * null;
 
 	//tested operations are performed within this block
 	{
@@ -2481,13 +2481,13 @@ TEST(Face_Cuts, Divided_Meet_Cut) {
 			boundary_small_b.append(Pint(3, 1));
 		}
 
-		FLL<Region *> exterior_med;
+		FLL<Region<Pint> *> exterior_med;
 
-		Region * product = new Region(&space, boundary_big);
+		auto product = space.region(boundary_big);
 
 		auto null_face = (*product)[0]->getRoot()->getInv()->getFace();
 
-		null = new Region(&space, null_face);
+		null = space.region(null_face);
 
 		subAllocate(product, boundary_small_a, exterior_med, interior);
 
@@ -2508,10 +2508,10 @@ TEST(Face_Cuts, Divided_Meet_Cut) {
 	ASSERT_NE(interior[2], nullptr);
 	ASSERT_NE(exterior[0], nullptr);
 
-	Region * interior_0 = interior[0];
-	Region * interior_1 = interior[1];
-	Region * interior_2 = interior[2];
-	Region * exterior_0 = exterior[0];
+	Region<Pint> * interior_0 = interior[0];
+	Region<Pint> * interior_1 = interior[1];
+	Region<Pint> * interior_2 = interior[2];
+	Region<Pint> * exterior_0 = exterior[0];
 
 	ASSERT_NE(interior_0, nullptr);
 	ASSERT_NE(interior_1, nullptr);

--- a/TESTS/TEST_region.cpp
+++ b/TESTS/TEST_region.cpp
@@ -207,25 +207,25 @@ TEST(Face_Cuts, Hole) {
 	auto area_null_0 = Pint::area(null_0->getLoopPoints());
 
 	EXPECT_TRUE(area_in_0_0 == rto(4));
-	EXPECT_TRUE(area_ex_0_0 == rto(400));
-	EXPECT_TRUE(area_ex_0_1 == rto(-4));
+	EXPECT_TRUE(area_ex_0_0 == rto(-4));
+	EXPECT_TRUE(area_ex_0_1 == rto(400));
 	EXPECT_TRUE(area_null_0 == rto(-400));
 
-	EXPECT_FALSE(interior_0_0->getNeighbors().contains(exterior_0_0));
-	EXPECT_TRUE(interior_0_0->getNeighbors().contains(exterior_0_1));
+	EXPECT_TRUE(interior_0_0->getNeighbors().contains(exterior_0_0));
+	EXPECT_FALSE(interior_0_0->getNeighbors().contains(exterior_0_1));
 	EXPECT_FALSE(interior_0_0->getNeighbors().contains(null_0));
 
-	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(interior_0_0));
+	EXPECT_TRUE(exterior_0_0->getNeighbors().contains(interior_0_0));
 	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(exterior_0_1));
-	EXPECT_TRUE(exterior_0_0->getNeighbors().contains(null_0));
+	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(null_0));
 
-	EXPECT_TRUE(exterior_0_1->getNeighbors().contains(interior_0_0));
+	EXPECT_FALSE(exterior_0_1->getNeighbors().contains(interior_0_0));
 	EXPECT_FALSE(exterior_0_1->getNeighbors().contains(exterior_0_0));
-	EXPECT_FALSE(exterior_0_1->getNeighbors().contains(null_0));
+	EXPECT_TRUE(exterior_0_1->getNeighbors().contains(null_0));
 
 	EXPECT_FALSE(null_0->getNeighbors().contains(interior_0_0));
-	EXPECT_TRUE(null_0->getNeighbors().contains(exterior_0_0));
-	EXPECT_FALSE(null_0->getNeighbors().contains(exterior_0_1));
+	EXPECT_FALSE(null_0->getNeighbors().contains(exterior_0_0));
+	EXPECT_TRUE(null_0->getNeighbors().contains(exterior_0_1));
 }
 
 
@@ -842,7 +842,7 @@ TEST(Face_Cuts, Stacked_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 28);
 	EXPECT_EQ(space.faceCount(), 4);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 4);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -952,7 +952,7 @@ TEST(Face_Cuts, Horshoe_Cut) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 28);
 	EXPECT_EQ(space.faceCount(), 4);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 4);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1325,7 +1325,7 @@ TEST(Face_Cuts, Exterior_Cut) {
 	EXPECT_EQ(space.pointCount(), 4);
 	EXPECT_EQ(space.edgeCount(), 8);
 	EXPECT_EQ(space.faceCount(), 2);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 2);
 
 	ASSERT_EQ(interior.size(), 0);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1373,7 +1373,7 @@ TEST(Face_Cuts, Encapsulating_Cut) {
 	EXPECT_EQ(space.pointCount(), 4);
 	EXPECT_EQ(space.edgeCount(), 8);
 	EXPECT_EQ(space.faceCount(), 2);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 2);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 0);
@@ -1460,7 +1460,7 @@ TEST(Face_Cuts, Seperate_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 24);
 	EXPECT_EQ(space.faceCount(), 6);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 4);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1606,7 +1606,7 @@ TEST(Face_Cuts, Adjacent_Meeting_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 26);
 	EXPECT_EQ(space.faceCount(), 5);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 4);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1733,7 +1733,7 @@ TEST(Face_Cuts, Adjacent_Crossing_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 26);
 	EXPECT_EQ(space.faceCount(), 5);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 4);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1862,7 +1862,7 @@ TEST(Face_Cuts, Connecting_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 28);
 	EXPECT_EQ(space.faceCount(), 4);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 4);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1988,7 +1988,7 @@ TEST(Face_Cuts, Connecting_Several_Holes) {
 	EXPECT_EQ(space.pointCount(), 16);
 	EXPECT_EQ(space.edgeCount(), 36);
 	EXPECT_EQ(space.faceCount(), 6);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 5);
 
 	ASSERT_EQ(interior.size(), 3);
 	ASSERT_EQ(exterior.size(), 1);
@@ -2127,7 +2127,7 @@ TEST(Face_Cuts, Splitting_Cut) {
 	EXPECT_EQ(space.pointCount(), 8);
 	EXPECT_EQ(space.edgeCount(), 20);
 	EXPECT_EQ(space.faceCount(), 4);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 4);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 2);
@@ -2243,7 +2243,7 @@ TEST(Face_Cuts, Divided_Crossing_Holes) {
 	EXPECT_EQ(space.pointCount(), 16);
 	EXPECT_EQ(space.edgeCount(), 36);
 	EXPECT_EQ(space.faceCount(), 6);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 5);
 
 	ASSERT_EQ(interior.size(), 3);
 	ASSERT_EQ(exterior.size(), 1);
@@ -2383,7 +2383,7 @@ TEST(Face_Cuts, Triangles_Crossing_Cut) {
 	EXPECT_EQ(space.pointCount(), 9);
 	EXPECT_EQ(space.edgeCount(), 22);
 	EXPECT_EQ(space.faceCount(), 4);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 4);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -2501,7 +2501,7 @@ TEST(Face_Cuts, Divided_Meet_Cut) {
 	EXPECT_EQ(space.pointCount(), 15);
 	EXPECT_EQ(space.edgeCount(), 36);
 	EXPECT_EQ(space.faceCount(), 5);
-	EXPECT_EQ(space.regionCount(), 3);
+	EXPECT_EQ(space.regionCount(), 5);
 
 	ASSERT_EQ(interior.size(), 3);
 	ASSERT_EQ(exterior.size(), 1);

--- a/TESTS/TEST_region.cpp
+++ b/TESTS/TEST_region.cpp
@@ -270,6 +270,7 @@ TEST(Face_Cuts, Edge_Meeting_Cut) {
 	EXPECT_EQ(space.pointCount(), 8);
 	EXPECT_EQ(space.edgeCount(), 18);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -364,6 +365,7 @@ TEST(Face_Cuts, Point_Meeting_Cut) {
 	EXPECT_EQ(space.pointCount(), 9);
 	EXPECT_EQ(space.edgeCount(), 20);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -457,6 +459,7 @@ TEST(Face_Cuts, Matching_Cut) {
 	EXPECT_EQ(space.pointCount(), 10);
 	EXPECT_EQ(space.edgeCount(), 22);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -551,6 +554,7 @@ TEST(Face_Cuts, Before_Overlapping_Cut) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 26);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -644,6 +648,7 @@ TEST(Face_Cuts, After_Overlapping_Cut) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 26);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -736,6 +741,7 @@ TEST(Face_Cuts, Overlapping_Cut) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 26);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -836,6 +842,7 @@ TEST(Face_Cuts, Stacked_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 28);
 	EXPECT_EQ(space.faceCount(), 4);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -945,6 +952,7 @@ TEST(Face_Cuts, Horshoe_Cut) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 28);
 	EXPECT_EQ(space.faceCount(), 4);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1050,6 +1058,7 @@ TEST(Face_Cuts, Corner_Meeting_Cut) {
 	EXPECT_EQ(space.pointCount(), 7);
 	EXPECT_EQ(space.edgeCount(), 16);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1138,6 +1147,7 @@ TEST(Face_Cuts, Edge_Crossing_Cut) {
 	EXPECT_EQ(space.pointCount(), 8);
 	EXPECT_EQ(space.edgeCount(), 18);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1226,6 +1236,7 @@ TEST(Face_Cuts, Corner_Crossing_Cut) {
 	EXPECT_EQ(space.pointCount(), 7);
 	EXPECT_EQ(space.edgeCount(), 16);
 	EXPECT_EQ(space.faceCount(), 3);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1314,6 +1325,7 @@ TEST(Face_Cuts, Exterior_Cut) {
 	EXPECT_EQ(space.pointCount(), 4);
 	EXPECT_EQ(space.edgeCount(), 8);
 	EXPECT_EQ(space.faceCount(), 2);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 0);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1361,6 +1373,7 @@ TEST(Face_Cuts, Encapsulating_Cut) {
 	EXPECT_EQ(space.pointCount(), 4);
 	EXPECT_EQ(space.edgeCount(), 8);
 	EXPECT_EQ(space.faceCount(), 2);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 0);
@@ -1447,6 +1460,7 @@ TEST(Face_Cuts, Seperate_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 24);
 	EXPECT_EQ(space.faceCount(), 6);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1592,6 +1606,7 @@ TEST(Face_Cuts, Adjacent_Meeting_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 26);
 	EXPECT_EQ(space.faceCount(), 5);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1718,6 +1733,7 @@ TEST(Face_Cuts, Adjacent_Crossing_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 26);
 	EXPECT_EQ(space.faceCount(), 5);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1846,6 +1862,7 @@ TEST(Face_Cuts, Connecting_Holes) {
 	EXPECT_EQ(space.pointCount(), 12);
 	EXPECT_EQ(space.edgeCount(), 28);
 	EXPECT_EQ(space.faceCount(), 4);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -1968,29 +1985,10 @@ TEST(Face_Cuts, Connecting_Several_Holes) {
 
 	//testing
 
-	/*EXPECT_EQ(exteriorPintrep_a.size(), 1);
-	EXPECT_EQ(interiorPintrep_a.size(), 1);
-	EXPECT_EQ(exteriorPintrep_b.size(), 1);
-	EXPECT_EQ(interiorPintrep_b.size(), 1);
-	EXPECT_EQ(exterior.size(), 1);
-	EXPECT_EQ(interior.size(), 1);
-
-	EXPECT_EQ(exterior[0]->getHoleCount(), 1);
-	EXPECT_EQ(interiorPintrep_a[0]->borderCount(10), 6);
-	EXPECT_EQ(interiorPintrep_b[0]->borderCount(10), 6);
-	EXPECT_EQ(interior[0]->borderCount(10), 4);
-	EXPECT_EQ(exterior[0]->borderCount(20), 4);
-	EXPECT_EQ(exterior[0]->holeBorderCount(0, 20), 12);
-
-	EXPECT_EQ(interiorPintrep_a[0]->getRootEdge()->loopArea(), 32);
-	EXPECT_EQ(interiorPintrep_b[0]->getRootEdge()->loopArea(), 32);
-	EXPECT_EQ(interior[0]->getRootEdge()->loopArea(), 120);
-	EXPECT_EQ(exterior[0]->getRootEdge()->loopArea(), 400);
-	EXPECT_EQ(exterior[0]->getHole(0)->loopArea(), -184);
-	*/
 	EXPECT_EQ(space.pointCount(), 16);
 	EXPECT_EQ(space.edgeCount(), 36);
 	EXPECT_EQ(space.faceCount(), 6);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 3);
 	ASSERT_EQ(exterior.size(), 1);
@@ -2129,6 +2127,7 @@ TEST(Face_Cuts, Splitting_Cut) {
 	EXPECT_EQ(space.pointCount(), 8);
 	EXPECT_EQ(space.edgeCount(), 20);
 	EXPECT_EQ(space.faceCount(), 4);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 2);
@@ -2244,6 +2243,7 @@ TEST(Face_Cuts, Divided_Crossing_Holes) {
 	EXPECT_EQ(space.pointCount(), 16);
 	EXPECT_EQ(space.edgeCount(), 36);
 	EXPECT_EQ(space.faceCount(), 6);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 3);
 	ASSERT_EQ(exterior.size(), 1);
@@ -2383,6 +2383,7 @@ TEST(Face_Cuts, Triangles_Crossing_Cut) {
 	EXPECT_EQ(space.pointCount(), 9);
 	EXPECT_EQ(space.edgeCount(), 22);
 	EXPECT_EQ(space.faceCount(), 4);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 2);
 	ASSERT_EQ(exterior.size(), 1);
@@ -2500,6 +2501,7 @@ TEST(Face_Cuts, Divided_Meet_Cut) {
 	EXPECT_EQ(space.pointCount(), 15);
 	EXPECT_EQ(space.edgeCount(), 36);
 	EXPECT_EQ(space.faceCount(), 5);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 3);
 	ASSERT_EQ(exterior.size(), 1);

--- a/TESTS/TEST_region.cpp
+++ b/TESTS/TEST_region.cpp
@@ -168,6 +168,7 @@ TEST(Face_Cuts, Hole) {
 	EXPECT_EQ(space.pointCount(), 8);
 	EXPECT_EQ(space.edgeCount(), 16);
 	EXPECT_EQ(space.faceCount(), 4);
+	EXPECT_EQ(space.regionCount(), 3);
 
 	ASSERT_EQ(interior.size(), 1);
 	ASSERT_EQ(exterior.size(), 1);
@@ -216,15 +217,15 @@ TEST(Face_Cuts, Hole) {
 
 	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(interior_0_0));
 	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(exterior_0_1));
-	EXPECT_FALSE(exterior_0_0->getNeighbors().contains(null_0));
+	EXPECT_TRUE(exterior_0_0->getNeighbors().contains(null_0));
 
 	EXPECT_TRUE(exterior_0_1->getNeighbors().contains(interior_0_0));
 	EXPECT_FALSE(exterior_0_1->getNeighbors().contains(exterior_0_0));
-	EXPECT_TRUE(exterior_0_1->getNeighbors().contains(null_0));
+	EXPECT_FALSE(exterior_0_1->getNeighbors().contains(null_0));
 
 	EXPECT_FALSE(null_0->getNeighbors().contains(interior_0_0));
-	EXPECT_FALSE(null_0->getNeighbors().contains(exterior_0_0));
-	EXPECT_TRUE(null_0->getNeighbors().contains(exterior_0_1));
+	EXPECT_TRUE(null_0->getNeighbors().contains(exterior_0_0));
+	EXPECT_FALSE(null_0->getNeighbors().contains(exterior_0_1));
 }
 
 


### PR DESCRIPTION
Moves base of regions into the DCEL structure, allowing for multi-face bounded regions to be represented natively. Does not support any native methods or restrictions for region composition. DCEL_Regions now contains definition for continuous 2D allocations, in terms of ratio points.